### PR TITLE
記事リンクに含まれる余分な()を削除

### DIFF
--- a/articles/0064/_posts/2024-09-10-0064-20thComments.md
+++ b/articles/0064/_posts/2024-09-10-0064-20thComments.md
@@ -134,7 +134,7 @@ tags: 0064
 
 ### id:bash0C7
 
-おめでとうございます！　わたしが直接関わったものとしては、初技術セッションだった[東京 Ruby 会議 01 での話の記事](({{base}}{% post_url articles/0024/2008-10-01-0024-TokyoRubyKaigi01Report %})) も、わたしが主催して豪雪だった[東京 Ruby 会議 10 レポート]({{base}}{% post_url articles/0041/2013-02-24-0041-TokyoRubyKaigi10Report_1st %}) も、いまでも時々読み返しています。
+おめでとうございます！　わたしが直接関わったものとしては、初技術セッションだった[東京 Ruby 会議 01 での話の記事]({{base}}{% post_url articles/0024/2008-10-01-0024-TokyoRubyKaigi01Report %}) も、わたしが主催して豪雪だった[東京 Ruby 会議 10 レポート]({{base}}{% post_url articles/0041/2013-02-24-0041-TokyoRubyKaigi10Report_1st %}) も、いまでも時々読み返しています。
 
 ### 志村 (hs9587)
 


### PR DESCRIPTION
意図しないページへのリンクになっています

<img width="671" alt="スクリーンショット 2024-10-28 13 39 14" src="https://github.com/user-attachments/assets/5402049f-ea3a-44d7-85c0-b3caabb94522">
<img width="420" alt="スクリーンショット 2024-10-28 13 39 20" src="https://github.com/user-attachments/assets/67835139-281d-442a-9940-302a4015497a">
